### PR TITLE
Add filter functionality

### DIFF
--- a/components/toolBar.vue
+++ b/components/toolBar.vue
@@ -1,6 +1,6 @@
 <template>
   <v-row class="d-flex justify-space-between">
-    <v-col sm="5">
+    <v-col cols="6" md="4">
       <v-select
         v-model="language"
         label="Language"
@@ -11,23 +11,34 @@
       ></v-select>
     </v-col>
     <v-spacer></v-spacer>
-    <v-col sm="3">
+    <v-col cols="6" md="4">
+      <v-select
+        v-model="filterOption"
+        label="Filter"
+        outlined
+        dense
+        :items="filterOptions"
+        :disabled="isLanguageSet(language)"
+        @change="emitFilter"
+      ></v-select>
+    </v-col>
+    <v-col cols="6" md="2">
       <v-btn
         justified
         min-height="40"
-        :disabled="isRestoreDisable(language)"
+        :disabled="isLanguageSet(language)"
         @click="restoreFile()"
       >
         RESTORE
       </v-btn>
     </v-col>
-    <v-col sm="3">
+    <v-col cols="6" md="2">
       <v-btn
         class="white--text"
         color="green lighten-1"
         min-height="40"
         download
-        :disabled="isDownloadDisable(language)"
+        :disabled="isLanguageSet(language)"
         @click="downloadFile()"
       >
         DOWNLOAD
@@ -60,11 +71,16 @@ export default {
       language: '',
       originalFileSHA: '',
       translatedFileSHA: '',
+      filterOption: '',
+      filterOptions: ['All', 'Translated', 'To be translated'],
     }
   },
   methods: {
     emitLang(event) {
       this.$emit('setLang', this.language)
+    },
+    emitFilter(event) {
+      this.$emit('setFilter', this.filterOption)
     },
     async downloadFile() {
       const fileKey = `p5js-website-translator.files.${this.page}.${this.language}`
@@ -94,10 +110,7 @@ export default {
       this.originalFileSHA = originalFileObj.commitSHA
       this.translatedFileSHA = translatedFileObj.commitSHA
     },
-    isDownloadDisable(language) {
-      return language.length === 0
-    },
-    isRestoreDisable(language) {
+    isLanguageSet(language) {
       return language.length === 0
     },
   },

--- a/pages/reference.vue
+++ b/pages/reference.vue
@@ -1,6 +1,10 @@
 <template>
   <v-layout column justify-center align-center>
-    <tool-bar page="reference" @setLang="setLanguage($event)"></tool-bar>
+    <tool-bar
+      page="reference"
+      @setLang="setLanguage($event)"
+      @setFilter="setFilter($event)"
+    ></tool-bar>
     <virtual-list
       class="list"
       style="height: 100vh; overflow-y: auto; width: 100%"
@@ -111,6 +115,7 @@ export default {
     }
     this.data = actions.buildCardsData(
       this.language,
+      this.filterOption,
       'reference',
       flattenedOriginalFile,
       flattenedTranslatedFile
@@ -122,11 +127,16 @@ export default {
       data: [],
       strKey: '',
       language: '',
+      filterOption: '',
     }
   },
   methods: {
     setLanguage(l) {
       this.language = l
+      this.$nuxt.refresh()
+    },
+    setFilter(f) {
+      this.filterOption = f
       this.$nuxt.refresh()
     },
   },

--- a/pages/website.vue
+++ b/pages/website.vue
@@ -1,6 +1,10 @@
 <template>
   <v-layout column justify-center align-center>
-    <tool-bar page="website" @setLang="setLanguage($event)"></tool-bar>
+    <tool-bar
+      page="website"
+      @setLang="setLanguage($event)"
+      @setFilter="setFilter($event)"
+    ></tool-bar>
     <virtual-list
       class="list"
       style="height: 100vh; overflow-y: auto; width: 100%"
@@ -114,6 +118,7 @@ export default {
     }
     this.data = actions.buildCardsData(
       this.language,
+      this.filterOption,
       'website',
       flattenedOriginalFile,
       flattenedTranslatedFile
@@ -125,11 +130,16 @@ export default {
       data: [],
       strKey: '',
       language: '',
+      filterOption: '',
     }
   },
   methods: {
     setLanguage(l) {
       this.language = l
+      this.$nuxt.refresh()
+    },
+    setFilter(f) {
+      this.filterOption = f
       this.$nuxt.refresh()
     },
   },

--- a/plugins/actions.js
+++ b/plugins/actions.js
@@ -3,12 +3,22 @@ const flat = require('flat')
 
 function buildCardsData(
   lang,
+  filterOption,
   webpage,
   flattenedOriginalFile,
   flattenedTranslatedFile
 ) {
   const data = []
   for (const key in flattenedOriginalFile) {
+    if (filterOption === 'Translated') {
+      if (flattenedOriginalFile[key] === flattenedTranslatedFile[key]) {
+        continue
+      }
+    } else if (filterOption === 'To be translated') {
+      if (flattenedOriginalFile[key] !== flattenedTranslatedFile[key]) {
+        continue
+      }
+    }
     const obj = {
       page: webpage,
       language: lang,


### PR DESCRIPTION
Add functionality that filters translation cards:
-  **All**:  All the strings from the translation file
-  **Translated**: Only the strings that have already been translated
-  **To be translated**: Only the strings that have to be translated (the cards marked in green)

Note: A key (and therefore a text card) is considered "To be translated" if the translated text is equal to the English version of the same key.